### PR TITLE
Fix unstuck when element located at the very top of the page.

### DIFF
--- a/src/vue-sticky-element.vue
+++ b/src/vue-sticky-element.vue
@@ -120,7 +120,7 @@ export default {
       this.forceHide = false;
     },
     toggleStickiness(relativeScrollPosToElement, goingStickyDirection) {
-      if (relativeScrollPosToElement < 0) {
+      if (relativeScrollPosToElement <= 0) {
         this.navbarStuck = false;
         if (this.shouldApplyTransition) {
           this.$nextTick().then(() => {


### PR DESCRIPTION
Page header does not unstuck when user scrolls back to page top.